### PR TITLE
fix(windows): refresh stale AppX profile cache after updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "typecheck": "tsc -p tsconfig.main.json --noEmit && tsc -p tsconfig.renderer.json --noEmit",
     "verify:application-menu": "npm run build:main && node scripts/verify-application-menu.mjs",
     "verify:paths": "npm run build:main && node scripts/verify-path-provider.mjs",
+    "verify:win-appx-cache-refresh": "npm run build:main && node scripts/verify-windows-appx-cache-refresh.mjs",
     "verify:win-launcher": "npm run build:main && node scripts/verify-windows-launcher.mjs",
     "verify:win-inheritance": "npm run build:main && node scripts/verify-windows-inheritance.mjs",
     "verify:win-profile-create": "npm run build:main && node scripts/verify-windows-profile-create-smoke.mjs",

--- a/scripts/verify-windows-appx-cache-refresh.mjs
+++ b/scripts/verify-windows-appx-cache-refresh.mjs
@@ -1,0 +1,53 @@
+process.env.CODEX_PROFILE_MANAGER_PLATFORM_OVERRIDE = "win32";
+process.env.LOCALAPPDATA = "C:\\Users\\Tester\\AppData\\Local";
+
+const {
+  currentWindowsAppxPathForManagedCache,
+  isWindowsAppxDesktopCachePath
+} = await import("../dist-electron/main/windows-appx-cache.js");
+
+const cacheRoot = "C:\\Users\\Tester\\AppData\\Local\\Codex Profile Manager\\WindowsAppsCache";
+const staleCachedExecutable = `${cacheRoot}\\OpenAI.Desktop_1.0.0.0_x64__test\\app\\ChatGPT.exe`;
+const installedExecutable = "C:\\Program Files\\WindowsApps\\OpenAI.Desktop_2.0.0.0_x64__test\\app\\ChatGPT.exe";
+const installedAppx = {
+  packageName: "OpenAI.Desktop",
+  packageFullName: "OpenAI.Desktop_2.0.0.0_x64__test",
+  packageFamilyName: "OpenAI.Desktop_test",
+  applicationId: "App",
+  installLocation: "C:\\Program Files\\WindowsApps\\OpenAI.Desktop_2.0.0.0_x64__test",
+  executablePath: installedExecutable,
+  productName: "ChatGPT"
+};
+
+assert(isWindowsAppxDesktopCachePath(staleCachedExecutable), "managed cache executables should be detected");
+assert(isWindowsAppxDesktopCachePath(staleCachedExecutable.toLowerCase()), "managed cache detection should be case-insensitive");
+assert(
+  currentWindowsAppxPathForManagedCache(staleCachedExecutable, () => installedAppx) === installedExecutable,
+  "managed cache executables should resolve to the currently installed AppX executable"
+);
+assert(
+  currentWindowsAppxPathForManagedCache(staleCachedExecutable, () => null) === null,
+  "managed cache executables should remain usable when no AppX package is installed"
+);
+
+for (const customPath of [
+  "C:\\Tools\\ChatGPT.exe",
+  installedExecutable,
+  "C:\\Users\\Tester\\AppData\\Local\\Codex Profile Manager\\WindowsAppsCache-Backup\\ChatGPT.exe"
+]) {
+  assert(!isWindowsAppxDesktopCachePath(customPath), `custom path should not be treated as managed cache: ${customPath}`);
+  assert(
+    currentWindowsAppxPathForManagedCache(customPath, () => {
+      throw new Error("AppX discovery must not run for custom paths");
+    }) === null,
+    `custom path should not be replaced: ${customPath}`
+  );
+}
+
+console.log("Windows AppX cache refresh verification passed.");
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}

--- a/src/main/registry.ts
+++ b/src/main/registry.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { ensureDir, readJsonFile, writeJsonFile } from "./fs-utils.js";
 import { getAppPaths, isWindowsCodexGuiExecutable, launcherFileName, resolveCodexDesktopApp, slugifyProfileName } from "./paths.js";
 import { pathExists } from "./fs-utils.js";
+import { currentWindowsAppxPathForManagedCache } from "./windows-appx-cache.js";
 import type { CreateProfileInput, ManagedProfile, ProfileRegistry, UpdateProfileInput } from "../shared/types.js";
 
 export const DEFAULT_PROFILE_ICON_BACKGROUND_COLOR = "#34C759";
@@ -172,6 +173,14 @@ export async function updateProfileCodexAppPath(profileId: string, codexAppPath:
 
 export async function repairProfileCodexAppPath(profile: ManagedProfile): Promise<ManagedProfile> {
   const resolvedDesktopApp = resolveCodexDesktopApp(profile.paths.codexAppPath);
+  const currentWindowsAppxPath = currentWindowsAppxPathForManagedCache(resolvedDesktopApp.executablePath);
+  if (currentWindowsAppxPath
+    && currentWindowsAppxPath !== profile.paths.codexAppPath
+    && await pathExists(currentWindowsAppxPath)
+    && isWindowsCodexGuiExecutable(currentWindowsAppxPath)) {
+    return updateProfileCodexAppPath(profile.id, currentWindowsAppxPath);
+  }
+
   if (resolvedDesktopApp.source === "preferred" && await pathExists(resolvedDesktopApp.executablePath) && isWindowsCodexGuiExecutable(resolvedDesktopApp.executablePath)) {
     return profile;
   }

--- a/src/main/windows-appx-cache.ts
+++ b/src/main/windows-appx-cache.ts
@@ -12,6 +12,32 @@ export interface CachedWindowsAppxDesktopApp extends WindowsAppxDesktopApp {
   cachedExecutablePath: string;
 }
 
+export function currentWindowsAppxPathForManagedCache(
+  candidatePath: string,
+  findInstalledAppx: () => WindowsAppxDesktopApp | null = findWindowsCodexAppxDesktopApp
+): string | null {
+  if (!isWindowsAppxDesktopCachePath(candidatePath)) {
+    return null;
+  }
+
+  return findInstalledAppx()?.executablePath ?? null;
+}
+
+export function isWindowsAppxDesktopCachePath(candidatePath: string): boolean {
+  if (getRuntimePlatform() !== "win32") {
+    return false;
+  }
+
+  const cacheRoot = path.win32.resolve(windowsAppxCacheRoot());
+  const resolvedCandidate = path.win32.resolve(candidatePath);
+  const relativePath = path.win32.relative(cacheRoot, resolvedCandidate);
+
+  return relativePath !== ""
+    && relativePath !== ".."
+    && !relativePath.startsWith(`..${path.win32.sep}`)
+    && !path.win32.isAbsolute(relativePath);
+}
+
 export async function ensureWindowsAppxDesktopCache(): Promise<CachedWindowsAppxDesktopApp | null> {
   if (getRuntimePlatform() !== "win32") {
     return null;


### PR DESCRIPTION
## Summary

- detect profile executables stored in the manager-owned WindowsAppsCache
- replace stale managed-cache paths with the currently installed AppX executable before launch
- preserve custom executable paths and keep the cached fallback when no AppX package is installed
- add regression coverage for stale caches, missing packages, case-insensitive paths, and custom paths

## Reproduction

1. Create and launch a profile from a Microsoft Store / AppX installation.
2. Leave the generated versioned cache in place.
3. Update the desktop app to a newer AppX package.
4. Launch the profile again.

Before this change, the old cached executable remained preferred because it still existed. This could leave the desktop client and bundled browser components on different releases.

After this change, manager-owned cache paths resolve through the currently installed AppX package, which lets the normal launch path prepare and use the matching versioned cache.

## Verification

- npm run typecheck
- npm run build
- npm run verify:win-appx-cache-refresh
- npm run verify:paths
- npm run verify:win-launcher
- npm run verify:win-profile-create